### PR TITLE
add support for Raspberry Pi Pico 

### DIFF
--- a/src/RadioBoards.h
+++ b/src/RadioBoards.h
@@ -26,6 +26,8 @@
   #include "maintained/SeeedStudio/WM1110.h"
 #elif defined(RADIO_BOARD_WIFI_LORA32)
   #include "maintained/Heltec/WiFi_LoRa32.h"
+#elif defined(RADIO_BOARD_RASPBERRYPI_PICO)
+  #include "contributed/RaspberryPi/PI_PICO.h"
 
 #else
   #error "Unsupported or unknown radio board!"

--- a/src/contributed/README.md
+++ b/src/contributed/README.md
@@ -1,0 +1,1 @@
+Boards added by other people

--- a/src/contributed/RaspberryPi/PI_PICO.h
+++ b/src/contributed/RaspberryPi/PI_PICO.h
@@ -6,8 +6,6 @@
 
 #define RADIO_BOARDS_NAME "Raspberry Pi Pico"
 
-SX1262 radio = new Module(3, 20, 15, 2, SPI1, RADIOLIB_DEFAULT_SPI_SETTINGS);
-
 #define RADIO_NSS     (3)   // i.e., SX1262 radio = new Module(3, 20, 15, 2, SPI1, RADIOLIB_DEFAULT_SPI_SETTINGS);
 #define RADIO_IRQ     (20)
 #define RADIO_RST     (15)

--- a/src/contributed/RaspberryPi/PI_PICO.h
+++ b/src/contributed/RaspberryPi/PI_PICO.h
@@ -7,6 +7,10 @@
 
 #define RADIO_BOARDS_NAME "Raspberry Pi Pico"
 
+#if RADIOLIB_SUPPORT_ENABLED
+  #define Radio       SX1262
+#endif
+
 #define RADIO_NSS     (3)   // i.e., SX1262 radio = new Module(3, 20, 15, 2, SPI1, RADIOLIB_DEFAULT_SPI_SETTINGS);
 #define RADIO_IRQ     (20)
 #define RADIO_RST     (15)
@@ -18,12 +22,10 @@
 #define RADIO_MOSI    (11)
 #define RADIO_SCK     (10)
 
-#define RADIO_SPI_INIT                                    \
-SPI1.setSCK(10);         \       // from https://github.com/jgromes/RadioLib/issues/729
-SPI1.setTX(11);          \       // ~
-SPI1.setRX(12);          \       // ~  
-pinMode(3, OUTPUT);      \       // ~
-digitalWrite(3, HIGH);   \       // ~
-RADIO_SPI1.begin(false);         // from https://github.com/jgromes/RadioLib/issues/729
+#define RADIO_SPI_INIT          \
+RADIO_SPI.setSCK(RADIO_SCK);    \
+RADIO_SPI.setTX(RADIO_MOSI);    \
+RADIO_SPI.setRX(RADIO_MISO);    \
+RADIO_SPI.begin(false);
 
 #endif

--- a/src/contributed/RaspberryPi/PI_PICO.h
+++ b/src/contributed/RaspberryPi/PI_PICO.h
@@ -1,0 +1,16 @@
+#if !defined(_RADIOBOARDS_CONTRIBUTED_RASPBERRYPI_PICO_H)
+#define _RADIOBOARDS_CONTRIBUTED_RASPBERRYPI_PICO_H
+
+// sources:
+// https://datasheets.raspberrypi.com/pico/Pico-R3-A4-Pinout.pdf
+
+#define RADIO_BOARDS_NAME "Raspberry Pi Pico"
+
+SX1262 radio = new Module(3, 20, 15, 2, SPI1, RADIOLIB_DEFAULT_SPI_SETTINGS);
+
+#define RADIO_NSS     (3)   // i.e., SX1262 radio = new Module(3, 20, 15, 2, SPI1, RADIOLIB_DEFAULT_SPI_SETTINGS);
+#define RADIO_IRQ     (20)
+#define RADIO_RST     (15)
+#define RADIO_GPIO    (2)
+
+#endif

--- a/src/contributed/RaspberryPi/PI_PICO.h
+++ b/src/contributed/RaspberryPi/PI_PICO.h
@@ -3,6 +3,7 @@
 
 // sources:
 // https://datasheets.raspberrypi.com/pico/Pico-R3-A4-Pinout.pdf
+// https://github.com/jgromes/RadioLib/issues/729
 
 #define RADIO_BOARDS_NAME "Raspberry Pi Pico"
 
@@ -10,5 +11,19 @@
 #define RADIO_IRQ     (20)
 #define RADIO_RST     (15)
 #define RADIO_GPIO    (2)
+
+// this board uses custom SPI to interface with the module
+#define RADIO_SPI     SPI1
+#define RADIO_MISO    (12)
+#define RADIO_MOSI    (11)
+#define RADIO_SCK     (10)
+
+#define RADIO_SPI_INIT                                    \
+SPI1.setSCK(10);         \       // from https://github.com/jgromes/RadioLib/issues/729
+SPI1.setTX(11);          \       // ~
+SPI1.setRX(12);          \       // ~  
+pinMode(3, OUTPUT);      \       // ~
+digitalWrite(3, HIGH);   \       // ~
+RADIO_SPI1.begin(false);         // from https://github.com/jgromes/RadioLib/issues/729
 
 #endif


### PR DESCRIPTION
added support for Raspberry Pi Pico microcontroller in 'contributed' folder.

** ref. the command syntax that is used w/ this board:

`SX1262 radio = new Module(3, 20, 15, 2, SPI1, RADIOLIB_DEFAULT_SPI_SETTINGS);`

UPDATE on 3-June-2024:    removed my request here for help with custom SPI... I remembered that the correct syntax for this board had already been determined from https://github.com/jgromes/RadioLib/issues/729      

However, while the provide syntax works in the sketch itself, I am not sure if I have positioned it properly in this Pull Request.   So, a close review is still required & appreciated!

Thank you!