### PR TITLE
Add RAKWireless RAK11300 Module

### DIFF
--- a/src/RadioBoards.h
+++ b/src/RadioBoards.h
@@ -110,6 +110,9 @@
 #elif defined(RADIO_BOARD_LILYGO_T3S3)
   #include "contributed/LilyGo/LilyGo_T3S3.h"
 
+#elif defined(RADIO_BOARD_RAKWIRELESS_RAK11300)
+  #include "contributed/RAKWireless/RAK11300.h"
+
 #else
   #error "Unsupported or unknown radio board!"
 

--- a/src/RadioBoards.h
+++ b/src/RadioBoards.h
@@ -43,6 +43,9 @@
 
   #elif defined(ARDUINO_LILYGO_T3S3_SX1262) || defined(ARDUINO_LILYGO_T3S3_SX1276) || defined(ARDUINO_LILYGO_T3S3_LR1121)
     #define RADIO_BOARD_LILYGO_T3S3
+
+  #elif defined(ARDUINO_RAKWIRELESS_RAK11300)
+    #define RADIO_BOARD_RAKWIRELESS_RAK11300
   
   #else
     #error "Unable to resolve board type automatically, please select one from the supported list"

--- a/src/contributed/RAKWireless/RAK11300.h
+++ b/src/contributed/RAKWireless/RAK11300.h
@@ -8,7 +8,7 @@
 //    Arduino-Pico: https://github.com/earlephilhower/arduino-pico/blob/5bd1a3a0f6f4df55053daf2c13c853f233501c81/variants/rakwireless_rak11300/pins_arduino.h#L6
 // Based on: https://www.nico-maas.de/?p=2607
 
-#define RADIO_BOARDS_NAME "RAKWireless WisDuo RAK11300"
+#define RADIO_BOARDS_NAME "RAKWireless RAK11300"
 
 #define RADIO_NSS     (PIN_SPI1_SS)
 #define RADIO_IRQ     (PIN_SX1262_DIO1)

--- a/src/contributed/RAKWireless/RAK11300.h
+++ b/src/contributed/RAKWireless/RAK11300.h
@@ -45,6 +45,6 @@
     {Module::MODE_IDLE,  {LOW}},                            \
     {Module::MODE_RX,    {HIGH}},                           \
     {Module::MODE_TX,    {HIGH}},                           \
-    {Module::MODE_IDLE,  {LOW}},                            \
+    END_OF_MODE_TABLE,                                      \
   };
 #endif

--- a/src/contributed/RAKWireless/RAK11300.h
+++ b/src/contributed/RAKWireless/RAK11300.h
@@ -1,0 +1,50 @@
+#if !defined(_RADIOBOARDS_CONTRIBUTED_RAK11300_H)
+#define _RADIOBOARDS_CONTRIBUTED_RAK11300_H
+
+// Pin definitions taken from:
+//    RAK definition: https://github.com/RAKWireless/RAK-RP-Arduino/
+//    RAK datasheet: https://docs.rakwireless.com/Product-Categories/WisDuo/RAK11300-Module/Datasheet/#overview
+//    Internal wiring of SX1262 module: https://forum.rakwireless.com/t/rak11300-pinout-rp2040-to-sx1262/8414/
+//    Arduino-Pico: https://github.com/earlephilhower/arduino-pico/blob/5bd1a3a0f6f4df55053daf2c13c853f233501c81/variants/rakwireless_rak11300/pins_arduino.h#L6
+// Based on: https://www.nico-maas.de/?p=2607
+
+#define RADIO_BOARDS_NAME "RAKWireless WisDuo RAK11300"
+
+#define RADIO_NSS     (PIN_SPI1_SS)
+#define RADIO_IRQ     (PIN_SX1262_DIO1)
+#define RADIO_RST     (PIN_SX1262_NRESET)
+#define RADIO_GPIO    (PIN_SX1262_BUSY)
+
+// this board uses custom SPI to interface with the module
+// SPI pins are configured in Arduino-Pico
+#define RADIO_SPI     SPI1
+
+#define RADIO_PIN_SX1262_ANT_PWR PIN_SX1262_ANT_PWR
+
+#define RADIO_SPI_INIT                                      \
+  RADIO_SPI.begin(RADIO_NSS);
+
+#endif
+
+
+#if RADIOLIB_SUPPORT_ENABLED
+  #define Radio       SX1262
+
+  // it also has custom RF switching
+  #define RADIO_RF_SWITCH
+
+  #define RADIO_RF_SWITCH_PINS                              \
+  static const uint32_t RadioBoards_rfswitch_pins[] = {     \
+      RADIO_PIN_SX1262_ANT_PWR,                             \
+      RADIOLIB_NC, RADIOLIB_NC, RADIOLIB_NC, RADIOLIB_NC    \
+    };
+
+  #define RADIO_RF_SWITCH_TABLE \
+  static const Module::RfSwitchMode_t RadioBoards_rfswitch_table[] = {  \
+    /* mode              ANT_PWR */                         \
+    {Module::MODE_IDLE,  {LOW}},                            \
+    {Module::MODE_RX,    {HIGH}},                           \
+    {Module::MODE_TX,    {HIGH}},                           \
+    {Module::MODE_IDLE,  {LOW}},                            \
+  };
+#endif


### PR DESCRIPTION
This PR adds support for the [RAK11300](https://store.rakwireless.com/products/wisduo-lpwan-module-rak11300) Module to RadioBoards to make it easier to use with RadioLib.

The code is mostly based on https://www.nico-maas.de/?p=2607 from @nmaas87

Features:
* Add support for RAK11300 with SX1262
* Use SPI1 as defined in Arduino-Pico
* Use custom RF Switch

TODO:
- [x] Auto detect board based on compiler flags (any flag that can we use?)